### PR TITLE
Add automatic authorization functionality using Twitch Developer API client id and secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ RUN ["chmod", "+x", "/home/script/entrypoint.sh"]
 
 ENTRYPOINT [ "/home/script/entrypoint.sh" ]
 
-CMD /bin/sh ./home/script/streamlink-recorder.sh ${streamOptions} ${streamLink} ${streamQuality} ${streamName}
+CMD /bin/bash ./home/script/streamlink-recorder.sh ${streamOptions} ${streamLink} ${streamQuality} ${streamName}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12.0a4-bullseye
-LABEL maintainer="lauwarm@mailbox.org"
+LABEL maintainer="junhyunglee@duck.com"
 
 ENV streamlinkCommit=34c5f5ee5953412c6214ad4a3c18dd08d1229c24
 ENV PATH "${HOME}/.local/bin:${PATH}"
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install gosu && apt-get install python3-pip -y
 
 RUN pip3 install --upgrade git+https://github.com/streamlink/streamlink.git@${streamlinkCommit}
 
-RUN  echo 'export PATH="${HOME}/.local/bin:${PATH}"'
+RUN echo 'export PATH="${HOME}/.local/bin:${PATH}"'
 
 RUN mkdir /home/download
 RUN mkdir /home/script
@@ -18,7 +18,7 @@ RUN mkdir /home/plugins
 #RUN cp /streamlink-plugins/*.py /home/plugins/
 
 COPY ./streamlink-recorder.sh /home/script/
-COPY ./entrypoint.sh /home/script
+COPY ./entrypoint.sh /home/script/
 
 RUN ["chmod", "+x", "/home/script/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,20 @@ Automated Dockerfile to record livestreams with streamlink
 
 This is a Docker Container to record a livestream. It uses the official [Python Image](https://hub.docker.com/_/python) with the Tag *bullseye*  , installs [streamlink](https://github.com/streamlink/streamlink) and uses the Script [streamlink-recorder.sh](https://raw.githubusercontent.com/lauwarm/docker-streamlink-recorder/main/streamlink-recorder.sh) to periodically check if the stream is live.
 
+This container has added functionality to turn off ads if the Twitch ID used to record the VODs are subscribed to the channel or has Twitch Turbo to skip ads.
+
 ## Usage
 
 To run the Container:
 
 ```bash
-docker run -v /path/to/vod/folder/:/home/download -e streamLink='' -e streamQuality='' -e streamName='' -e streamOptions='' -e uid='' -e gid='' lauwarm/streamlink-recorder
+docker run -v /path/to/vod/folder/:/home/download -e streamLink='' -e streamQuality='' -e streamName='' -e streamOptions='' -e clientId='' -e clientSecret='' -e uid='' -e gid='' lauwarm/streamlink-recorder
 ```
 
 Example:
 
 ```bash
-docker run -v /home/:/home/download -e streamLink='twitch.tv/twitch' -e streamQuality='best' -e streamName='twitch' -e streamOptions='--twitch-disable-reruns' -e uid='1001' -e gid='1001' lauwarm/streamlink-recorder
+docker run -v /home/:/home/download -e streamLink='twitch.tv/twitch' -e streamQuality='best' -e streamName='twitch' -e streamOptions='--twitch-disable-ads' -e clientId='twitch-client-id' clientSecret='twitch-client-secret' -e uid='1001' -e gid='1001' junhyunglee/streamlink-recorder
 ```
 
 ## Notes
@@ -36,8 +38,16 @@ docker run -v /home/:/home/download -e streamLink='twitch.tv/twitch' -e streamQu
 
 `streamOptions` - streamlink flags (--twitch-disable-reruns, separated by space, see [Plugins](https://streamlink.github.io/plugins.html))
 
+`clientId` - Twitch API client id from [Twitch Developer Console](https://dev.twitch.tv).
+
+`clientSecret` - Twitch API client secret generated from [Twitch Developer Console](https://dev.twitch.tv).
+
 `uid` - USER ID, map to your desired User ID (fallback to 9001)
 
 `gid` - GROUP ID, map to your desired Group ID (fallback to 9001)
 
 The File will be saved as `streamName-YearMonthDay-HourMinuteSecond.mkv`
+
+## Reference
+
+This is a forked repo from lauwarm/docker-streamlink-recorder.

--- a/streamlink-recorder.sh
+++ b/streamlink-recorder.sh
@@ -5,7 +5,7 @@
 oauth_token = ''
 
 function get_oauth_token() {
-	oauth_token = $(curl -s -X POST -H "Client-ID: $clientId" -d "client_id=$clientId&client_secret=$clientSecret&grant_type=client_credentials" https://id.twitch.tv/oauth2/token | jq -r '.access_token')
+	$oauth_token = $(curl -s -X POST -H "Client-ID: $clientId" -d "client_id=$clientId&client_secret=$clientSecret&grant_type=client_credentials" https://id.twitch.tv/oauth2/token | jq -r '.access_token')
 }
 
 function validate_oauth_token() {

--- a/streamlink-recorder.sh
+++ b/streamlink-recorder.sh
@@ -2,8 +2,22 @@
 
 # For more information visit: https://github.com/downthecrop/TwitchVOD
 
+oauth_token = ''
+
+function get_oauth_token() {
+	oauth_token = $(curl -s -X POST -H "Client-ID: $clientId" -d "client_id=$clientId&client_secret=$clientSecret&grant_type=client_credentials" https://id.twitch.tv/oauth2/token | jq -r '.access_token')
+}
+
+function validate_oauth_token() {
+	if $(curl -X GET -H "Authorization: OAuth $1" https://id.twitch.tv/oauth2/validate | jq -r '.status') -eq 401; then
+		get_oauth_token
+	fi
+}
+
 while [ true ]; do
 	Date=$(date +%Y%m%d-%H%M%S)
+	validate_oauth_token $oauth_token
+	$streamOptions += " --twitch-api-header=\"Authorization=OAuth $oauth_token\""
 	streamlink $streamOptions $streamLink $streamQuality -o /home/download/$streamName"-$Date".mkv
 	sleep 60s
 done


### PR DESCRIPTION
The new script will periodically pull OAuth token using Twitch developer client id and secret to bypass ads if possible.